### PR TITLE
log: place log file in $HOME/.cache to follow XDG

### DIFF
--- a/plasmoid/contents/ui/config/ConfigAdvanced.qml
+++ b/plasmoid/contents/ui/config/ConfigAdvanced.qml
@@ -184,7 +184,7 @@ Item {
 		            id: buttonRow
 		            PlasmaComponents.CheckBox {
 			            id: enableDebug
-			            text: i18n('Enable debug (log file will be placed in your home, named caffeine-plugs-debug.log)')
+			            text: i18n('Enable debug log in $HOME/.cache/caffeine-plus-debug.log')
 			            Layout.columnSpan: 2
 			        }
 		        }

--- a/plugin/caffeine-plus.cpp
+++ b/plugin/caffeine-plus.cpp
@@ -45,8 +45,8 @@ void CaffeinePlus::init(bool enableFullscreen, const QStringList &userApps, bool
     m_userApps = userApps;
     m_enableFullscreen = enableFullscreen;
     m_enableDebug = enableDebug;
-	m_isInited = true;
-	m_debug_log = QString("%1/caffeine-plugs-debug.log").arg(QDir::homePath());
+    m_isInited = true;
+    m_debug_log = QString("%1/caffeine-plus-debug.log").arg(QStandardPaths::CacheLocation);
     logInfo("system");
 
     qDBusRegisterMetaType<QList<InhibitionInfo>>();


### PR DESCRIPTION
Instead of littering in $HOME, place the log file in $HOME/.cache instead